### PR TITLE
Force the X11 GDK backend in the launch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ instructions for testers:
 
    1) get NW.js from their website. (SDK or normal build does not matter.)
    2) clone the repo
-   3) Launch it with `/path/to/nw_extraction_dir/nw --disable-gpu --force-cpu-draw --enable-transparent-visuals --disable-gpu-compositing /path/to/SHIT-Frontend`
+   3) Launch it with `GDK_BACKEND=x11 /path/to/nw_extraction_dir/nw --disable-gpu --force-cpu-draw --enable-transparent-visuals --disable-gpu-compositing /path/to/SHIT-Frontend`
 
 **Note**: handwriting recognition does not actually work yet, this build is simply to test cell sizing etc


### PR DESCRIPTION
It's my understanding that this is a Linux-only project. At the moment, NW has a problem where, despite only running via X11, it will still respect the GDK_BACKEND environment variable. This leads to a fairly cryptic error message on init, followed promptly by the app exiting with error code 1.

As Wayland is becoming more common, this PR changes the recommended launch command in the README to force the use of the X11 backend. That's it.